### PR TITLE
fix: Use `raw` pattern for semver tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             type=ref,event=branch
             type=sha,format=long
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
I think this will solve the issue with the docker image not getting pulled down when this action is invoked.

I noticed that output of workflows trying to download this action say `docker pull ghcr.io/observiq/otel-distro-builder:v1` and the output is `Error response from daemon: manifest unknown`. However if you look at the docker package being published, the command there is `docker pull ghcr.io/observiq/otel-distro-builder:1.0.6`, the difference being the lack of a `v` in the version. 

I confirmed I can manually run `docker pull ghcr.io/observiq/otel-distro-builder:1.0.6` with success but not `docker pull ghcr.io/observiq/otel-distro-builder:v1` or `docker pull ghcr.io/observiq/otel-distro-builder:v1.0.6`, both returning the manifest unknown error.

I first tried changing the references to the action to not use a v, but I was getting back errors when attempting that. Instead I think we need to update how the docker image is being published so that the semver tag is using the raw tag we push to github i.e. with the `v`.