### PR TITLE
fix: Use relative path in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ outputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/observiq/otel-distro-builder:v1"
+  image: "builder/Dockerfile"
   env:
     INPUT_MANIFEST: ${{ inputs.manifest }}
     INPUT_OUTPUT_DIR: ${{ inputs.output-dir }}


### PR DESCRIPTION
Right now we only look and use the docker image specified in this file. When invoking this action, it checks out the repo at the ref you provide, i.e. tag `v1.0.7` in this example:
```
- name: OpenTelemetry Distribution Builder
  uses: observIQ/otel-distro-builder@v1.0.7
```

The action will check out the repo and then use the `action.yml` to figure out how to run the action. In this case we are hardcoding the action to check out the docker image `docker://ghcr.io/observiq/otel-distro-builder:v1`. Instead it should checkout the Dockerfile in the github ref we're getting. 