### PR TITLE
feat: Goreleaser snapshot flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
   snapshot:
     description: "Run goreleaser in snapshot mode"
     required: false
-    default: "true"
+    default: "false"
 
 outputs:
   name:

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Version of Go to use for building"
     required: false
     default: "1.24.1"
+  snapshot:
+    description: "Run goreleaser in snapshot mode"
+    required: false
+    default: "true"
 
 outputs:
   name:
@@ -48,6 +52,7 @@ runs:
     INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload_artifacts }}
     INPUT_SUPERVISOR_VERSION: ${{ inputs.supervisor_version }}
     INPUT_GO_VERSION: ${{ inputs.go_version }}
+    INPUT_SNAPSHOT: ${{ inputs.snapshot }}
 
 branding:
   icon: "package"

--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 # Handle platform specifications
 if [ -n "$INPUT_PLATFORMS" ]; then
     # Split platforms into GOOS and GOARCH
-    IFS='/' read -r goos goarch <<< "$INPUT_PLATFORMS"
+    IFS='/' read -r goos goarch <<<"$INPUT_PLATFORMS"
     if [ -n "$goos" ]; then
         ARGS="$ARGS --goos $goos"
     fi
@@ -45,7 +45,12 @@ if [ -n "$INPUT_GO_VERSION" ]; then
     ARGS="$ARGS --go-version $INPUT_GO_VERSION"
 fi
 
+# Handle snapshot mode
+if [ -n "$INPUT_SNAPSHOT" ]; then
+    ARGS="$ARGS --snapshot $INPUT_SNAPSHOT"
+fi
+
 echo "Executing: python /app/builder/src/main.py $ARGS"
 
 # Execute the Python script with the converted arguments
-exec python /app/builder/src/main.py $ARGS 
+exec python /app/builder/src/main.py $ARGS

--- a/builder/src/build.py
+++ b/builder/src/build.py
@@ -120,6 +120,7 @@ class BuildContext:
         ocb_version: Optional[str] = None,
         supervisor_version: Optional[str] = None,
         go_version: Optional[str] = "1.24.1",
+        snapshot: Optional[bool] = True,
     ):
         """Create a BuildContext from manifest content."""
         goos = goos or ["linux"]
@@ -209,6 +210,7 @@ class BuildContext:
             supervisor_version=supervisor_version,
             go_version=go_version,
             manifest_path=manifest_path,
+            snapshot=snapshot,
         )
 
 
@@ -359,11 +361,13 @@ def build_release(ctx: BuildContext) -> bool:
     logger.section("Release Building")
     logger.info(f"Building release for {ctx.distribution} with goreleaser")
 
-    cmd = "goreleaser --snapshot --clean"
+    # Determine if snapshot flag should be used
+    snapshot_flag = "--snapshot" if ctx.snapshot else ""
+    cmd = f"goreleaser {snapshot_flag} --clean"
     logger.command(cmd)
 
     result = subprocess.run(
-        ["goreleaser", "--snapshot", "--clean"],
+        [arg for arg in ["goreleaser", snapshot_flag, "--clean"] if arg],
         cwd=ctx.build_dir,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -433,6 +437,7 @@ def build(
     ocb_version: Optional[str] = None,
     supervisor_version: Optional[str] = None,
     go_version: Optional[str] = DEFAULT_GO_VERSION,
+    snapshot: Optional[bool] = True,
 ) -> bool:
     """Build an OpenTelemetry Collector distribution.
 

--- a/builder/src/build.py
+++ b/builder/src/build.py
@@ -120,7 +120,7 @@ class BuildContext:
         ocb_version: Optional[str] = None,
         supervisor_version: Optional[str] = None,
         go_version: Optional[str] = "1.24.1",
-        snapshot: Optional[bool] = True,
+        snapshot: Optional[bool] = False,
     ):
         """Create a BuildContext from manifest content."""
         goos = goos or ["linux"]
@@ -373,7 +373,7 @@ def build_release(ctx: BuildContext) -> bool:
         stderr=subprocess.STDOUT,
         text=True,
         check=False,
-    )  # Ensure output is decoded as text
+    )
 
     # Always show goreleaser output
     if result.stdout:
@@ -437,7 +437,7 @@ def build(
     ocb_version: Optional[str] = None,
     supervisor_version: Optional[str] = None,
     go_version: Optional[str] = DEFAULT_GO_VERSION,
-    snapshot: Optional[bool] = True,
+    snapshot: Optional[bool] = False,
 ) -> bool:
     """Build an OpenTelemetry Collector distribution.
 

--- a/builder/src/main.py
+++ b/builder/src/main.py
@@ -61,7 +61,7 @@ def main() -> None:
     parser.add_argument(
         "--snapshot",
         type=bool,
-        default=True,
+        default=False,
         help="Run goreleaser in snapshot mode",
     )
     args = parser.parse_args()

--- a/builder/src/main.py
+++ b/builder/src/main.py
@@ -58,6 +58,12 @@ def main() -> None:
         default="1.24.1",
         help="Version of Go to use for building",
     )
+    parser.add_argument(
+        "--snapshot",
+        type=bool,
+        default=True,
+        help="Run goreleaser in snapshot mode",
+    )
     args = parser.parse_args()
 
     # Set log level to INFO


### PR DESCRIPTION
This makes running goreleaser with the `--snapshot` flag configurable. The default is to run without the flag which should generate a release in the repository the action is ran in.