### PR TITLE
chore: Set template for snapshot names

### DIFF
--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -160,8 +160,12 @@ nfpms:
           owner: __DISTRIBUTION__
           group: __DISTRIBUTION__
 
+snapshot:
+  name_template: "v{{ .Version }}"
+
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
+
 sboms:
   - id: archive
     artifacts: archive

--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -59,6 +59,7 @@ archives:
 
 nfpms:
   - package_name: __DISTRIBUTION__
+    file_name_template: '{{ .PackageName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     bindir: /opt/__DISTRIBUTION__
     scripts:
       preinstall: preinstall.sh
@@ -116,6 +117,7 @@ nfpms:
           group: __DISTRIBUTION__
 
   - package_name: __DISTRIBUTION___otelcol
+    file_name_template: '{{ .PackageName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     bindir: /opt/__DISTRIBUTION__
     scripts:
       preinstall: preinstall.sh
@@ -161,7 +163,7 @@ nfpms:
           group: __DISTRIBUTION__
 
 snapshot:
-  name_template: "v{{ .Version }}"
+  name_template: "{{ .Version }}"
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"


### PR DESCRIPTION
Using a template to define the snapshot version that's used so we don't generate artifacts with `SNAPSHOT` in the name. Goreleaser documentation: https://goreleaser.com/customization/snapshots/