### PR TITLE
chore: Use goreleaser v2

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.9-slim-bookworm
 
 # Version definitions for easy updates
-ENV GORELEASER_VERSION=1.26.2
+ENV GORELEASER_VERSION=2.8.1
 ENV SYFT_VERSION=1.21.0
 ENV OCB_VERSIONS="0.120.0 0.121.0 0.122.0"
 ENV GO_VERSIONS="1.24.1"

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -49,9 +49,9 @@ RUN echo '#!/bin/bash\n\
 
 # Install goreleaser based on architecture
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-    wget -q -O- https://github.com/goreleaser/goreleaser-pro/releases/download/v${GORELEASER_VERSION}-pro/goreleaser-pro_Linux_arm64.tar.gz | tar -C /usr/local/bin -xzf - goreleaser; \
+    wget -q -O- https://github.com/goreleaser/goreleaser-pro/releases/download/v${GORELEASER_VERSION}/goreleaser-pro_Linux_arm64.tar.gz | tar -C /usr/local/bin -xzf - goreleaser; \
     else \
-    wget -q -O- https://github.com/goreleaser/goreleaser-pro/releases/download/v${GORELEASER_VERSION}-pro/goreleaser-pro_Linux_x86_64.tar.gz | tar -C /usr/local/bin -xzf - goreleaser; \
+    wget -q -O- https://github.com/goreleaser/goreleaser-pro/releases/download/v${GORELEASER_VERSION}/goreleaser-pro_Linux_x86_64.tar.gz | tar -C /usr/local/bin -xzf - goreleaser; \
     fi && \
     chmod +x /usr/local/bin/goreleaser
 

--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
       - CGO_ENABLED=0
 archives:
   - id: __DISTRIBUTION__
-    builds:
+    ids:
       - __DISTRIBUTION__
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     files:
@@ -48,7 +48,7 @@ archives:
         formats: ["zip"]
 
   - id: __DISTRIBUTION___otelcol
-    builds:
+    ids:
       - __DISTRIBUTION__
     name_template: "{{ .ProjectName }}_otelcol_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     files:
@@ -67,7 +67,7 @@ nfpms:
       postinstall: postinstall.sh
       preremove: preremove.sh
     id: __DISTRIBUTION__
-    builds:
+    ids:
       - __DISTRIBUTION__
     formats:
       - apk
@@ -125,7 +125,7 @@ nfpms:
       postinstall: postinstall.sh
       preremove: preremove.sh
     id: __DISTRIBUTION___otelcol
-    builds:
+    ids:
       - __DISTRIBUTION__
     formats:
       - apk

--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -164,7 +164,7 @@ nfpms:
           group: __DISTRIBUTION__
 
 snapshot:
-  name_template: "{{ .Version }}"
+  version_template: "{{ .Version }}"
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"

--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: __DISTRIBUTION__
 env:
   - COSIGN_YES=true
@@ -44,7 +45,7 @@ archives:
         dst: "service/__DISTRIBUTION__.conf"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
   - id: __DISTRIBUTION___otelcol
     builds:


### PR DESCRIPTION
Updates the action to use goreleaser v2. Only required change to the template is adding the `version` field at the top of the file.

To check compatibility, I ran `goreleaser check builder/templates/.goreleaser.yaml`. For this to work though, need to make a temporary change to the `builds.goos` and `builds.goarch` to be an array instead of the template vars otherwise it will fail.

Changes other than the version field are to address deprecations in the config when checked against the latest goreleaser version (v2.8.1).

There is one other deprecation present in the current goreleaer config that isn't fixed right now - setting the `nfpms.maintainer` section. This will be a required value at some point,  but I'm not sure what we want to set this with?