### PR TITLE
fix: Format override for otelcol archive

### DIFF
--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -61,6 +61,9 @@ archives:
         dst: "service/__DISTRIBUTION__.conf"
       - src: __DISTRIBUTION___otelcol.plist
         dst: "service/__DISTRIBUTION__.plist"
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
 
 nfpms:
   - package_name: __DISTRIBUTION__


### PR DESCRIPTION
The OTel Collector only archive build was missing a format override for windows (changing type from .tar.gz to .zip)