### PR TITLE
Fix docs repo link

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -234,5 +234,5 @@ When `upload_artifacts` is enabled:
 
 - [OpenTelemetry Collector Documentation](https://opentelemetry.io/docs/collector/)
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [GitHub Repository](https://github.com/observiq/otel-distor-builder)
+- [GitHub Repository](https://github.com/observiq/otel-distro-builder)
 - [Issue Tracker](https://github.com/observiq/otel-distro-builder/issues)


### PR DESCRIPTION
## Summary
- fix GitHub repo link in the GitHub Actions guide

## Testing
- `git status --short`
