### PR TITLE
docs: fix accuracy issues in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It handles all the complex aspects of managing your own distribution that have h
 
 ## 📥 Install
 
-The CLI runs on your host and reads config/manifest files from the host filesystem. **Docker is not required** for manifest generation or for full builds when Go (and OCB) are available on the host.
+The CLI runs on your host and reads config/manifest files from the host filesystem. **Docker is not required**—the CLI downloads OCB and Go automatically when needed for full builds.
 
 | Method | Command |
 |--------|---------|
@@ -46,7 +46,7 @@ The CLI runs on your host and reads config/manifest files from the host filesyst
 
 Then run `otel-distro-builder --help`.
 
-**Dependencies:** For **manifest generation** (`--from-config`, `--generate-only`), the standalone binary and pip install need **no other dependencies**. For **full distribution builds** on the host, **Go is the only required dependency**—the CLI downloads the OpenTelemetry Collector Builder (OCB) automatically. Docker is optional and only for an isolated build environment.
+**Dependencies:** For **manifest generation** (`--from-config`, `--generate-only`), the standalone binary and pip install need **no other dependencies**. For **full distribution builds** on the host, **no other dependencies are required**—the CLI downloads OCB and Go automatically when needed. Docker is optional and only for an isolated build environment.
 
 ## 🚀 Quick Start
 
@@ -126,7 +126,7 @@ on:
 
 ## 🔄 Generate Manifest from Existing Config
 
-Already have a running OpenTelemetry Collector with a `config.yaml`? Generate a minimal manifest containing only the components you need. **No Docker required**—run the CLI on your host (after [install](#-install)); for full builds you need Go installed and the CLI will download OCB automatically.
+Already have a running OpenTelemetry Collector with a `config.yaml`? Generate a minimal manifest containing only the components you need. **No Docker required**—run the CLI on your host (after [install](#-install)); for full builds, no other dependencies are required—the CLI downloads OCB and Go automatically.
 
 ```bash
 # Generate manifest only (prints to stdout)
@@ -180,10 +180,15 @@ To view detailed guides, see the [docs](./docs) directory.
 
 #### Inputs
 
-| Input       | Description           | Default           |
-| ----------- | --------------------- | ----------------- |
-| `manifest`  | Path to manifest file | `./manifest.yaml` |
-| `platforms` | Target platforms      | `linux/amd64`     |
+| Input                | Description                                      | Default                       | Required |
+| -------------------- | ------------------------------------------------ | ----------------------------- | -------- |
+| `manifest`           | Path to manifest file                            | `./manifest.yaml`             | Yes      |
+| `artifact_dir`       | Directory to store build artifacts               | `/github/workspace/artifacts` | Yes      |
+| `os`                 | Target operating systems (comma-separated)       | `linux`                       | No       |
+| `arch`               | Target architectures (comma-separated)           | `amd64`                       | No       |
+| `ocb_version`        | OpenTelemetry Collector Builder version          | —                             | No       |
+| `supervisor_version` | Supervisor version                               | —                             | No       |
+| `go_version`         | Go version for building                          | —                             | No       |
 
 #### Outputs
 
@@ -274,7 +279,7 @@ When building for multiple architectures or large manifests, the number of paral
 
 ### Prerequisites
 
-- **Using the CLI (binary or pip):** For full builds, only [Go](https://go.dev/dl/) is required; OCB is downloaded by the CLI. For manifest generation only, no dependencies.
+- **Using the CLI (binary or pip):** For full builds, no other dependencies are required; the CLI downloads OCB and Go automatically. For manifest generation only, no dependencies.
 - **Development (editing this repo):** Python 3, Make. Docker is optional (for running the builder in a container).
 
 ### Available Commands
@@ -332,7 +337,7 @@ Options: `-m` (required), `-o` (output dir), `-p` (platforms), `-v` (OCB version
 
 Via Make: `make build`, `make build-local`, `make build output_dir=./artifacts ocb_version=0.121.0`, `make build platforms=linux/arm64,linux/amd64`.
 
-**Multi-arch builds** use the same script with `-p` (omit `-p` for single-arch default linux/arm64):
+**Multi-arch builds** use the same script with `-p` (omit `-p` for single-arch; defaults to the host platform):
 
 ```bash
 # Multi-arch: linux + darwin, amd64 + arm64

--- a/docs/config-to-manifest.md
+++ b/docs/config-to-manifest.md
@@ -10,7 +10,7 @@ If you already have a running OpenTelemetry Collector with a `config.yaml` file,
 2. Generate a minimal `manifest.yaml` containing only those components
 3. Optionally build a custom collector distribution in the same run
 
-You get a smaller, more efficient collector binary that includes only the components you use. **No Docker required**—the CLI runs on your host; for full builds you need Go installed and the CLI downloads OCB automatically.
+You get a smaller, more efficient collector binary that includes only the components you use. **No Docker required**—the CLI runs on your host; for full builds, no other dependencies are required—the CLI downloads OCB and Go automatically.
 
 ## Quick Start (Host CLI)
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -42,6 +42,9 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -52,33 +55,33 @@ jobs:
         uses: observiq/otel-distro-builder@v1
         with:
           manifest: "./manifest.yaml"
-          output-dir: "./artifacts"
-          create_release: true
-          upload_artifacts: true
-          platforms: "linux/amd64,linux/arm64"
+          artifact_dir: "${{ github.workspace }}/artifacts"
+          os: "linux"
+          arch: "amd64,arm64"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ github.workspace }}/artifacts/*
 ```
 
 ## Available Inputs
 
 The GitHub Action accepts the following inputs:
 
-| Input              | Description                        | Default           | Required |
-| ------------------ | ---------------------------------- | ----------------- | -------- |
-| `manifest`         | Path to manifest file              | `./manifest.yaml` | Yes      |
-| `output-dir`       | Output directory for artifacts     | `./artifacts`     | No       |
-| `create_release`   | Create GitHub release              | `true`            | No       |
-| `upload_artifacts` | Upload to Actions artifacts        | `true`            | No       |
-| `platforms`        | Target platforms (comma-separated) | `linux/amd64`     | No       |
+| Input                | Description                                    | Default                       | Required |
+| -------------------- | ---------------------------------------------- | ----------------------------- | -------- |
+| `manifest`           | Path to manifest file                          | `./manifest.yaml`             | Yes      |
+| `artifact_dir`       | Directory to store build artifacts             | `/github/workspace/artifacts` | Yes      |
+| `os`                 | Target operating systems (comma-separated)     | `linux`                       | No       |
+| `arch`               | Target architectures (comma-separated)         | `amd64`                       | No       |
+| `ocb_version`        | OpenTelemetry Collector Builder version        | —                             | No       |
+| `supervisor_version` | Supervisor version                             | —                             | No       |
+| `go_version`         | Go version for building                        | —                             | No       |
 
 ## Outputs
 
-The action provides the following outputs:
-
-| Output           | Description                    |
-| ---------------- | ------------------------------ |
-| `name`           | Name of the built collector    |
-| `version`        | Version of the built collector |
-| `artifacts_path` | Path to the built artifacts    |
+The action does not expose formal step outputs. All generated artifacts are written to the directory specified by `artifact_dir`. Use a separate step (e.g. `softprops/action-gh-release`) to upload them to a GitHub Release or elsewhere.
 
 ## Example Workflows
 
@@ -92,6 +95,9 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -104,8 +110,12 @@ jobs:
         uses: observiq/otel-distro-builder@v1
         with:
           manifest: "./manifest.yaml"
-          create_release: true
-          upload_artifacts: true
+          artifact_dir: "${{ github.workspace }}/artifacts"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ github.workspace }}/artifacts/*
 ```
 
 ### Multi-Platform Build
@@ -118,6 +128,9 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -128,9 +141,14 @@ jobs:
         uses: observiq/otel-distro-builder@v1
         with:
           manifest: "./manifest.yaml"
-          platforms: "linux/amd64,linux/arm64,linux/arm/v7"
-          create_release: true
-          upload_artifacts: true
+          artifact_dir: "${{ github.workspace }}/artifacts"
+          os: "linux,darwin"
+          arch: "amd64,arm64"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ github.workspace }}/artifacts/*
 ```
 
 ### Custom Output Directory
@@ -143,6 +161,9 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -153,9 +174,12 @@ jobs:
         uses: observiq/otel-distro-builder@v1
         with:
           manifest: "./manifest.yaml"
-          output-dir: "./dist"
-          create_release: true
-          upload_artifacts: true
+          artifact_dir: "${{ github.workspace }}/dist"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ github.workspace }}/dist/*
 ```
 
 ## Artifacts and Releases
@@ -172,19 +196,25 @@ The builder will generate the following artifacts:
 
 ### GitHub Release
 
-When `create_release` is enabled:
+The action does not create releases itself. Add a separate step using `softprops/action-gh-release` (or similar) to upload the contents of `artifact_dir` to a GitHub Release:
 
-- A new GitHub release is created with the tag name
-- All artifacts are attached to the release
-- Release notes are generated from commit messages
+```yaml
+- name: Create Release
+  uses: softprops/action-gh-release@v2
+  with:
+    files: ${{ github.workspace }}/artifacts/*
+```
 
 ### Actions Artifacts
 
-When `upload_artifacts` is enabled:
+To upload artifacts to GitHub Actions for download from the Actions UI, add an `actions/upload-artifact` step after the build:
 
-- All built artifacts are uploaded to GitHub Actions
-- Available for download from the Actions UI
-- Can be used by subsequent workflow steps
+```yaml
+- uses: actions/upload-artifact@v4
+  with:
+    name: collector-artifacts
+    path: ${{ github.workspace }}/artifacts/*
+```
 
 ## Best Practices
 

--- a/docs/local-build-script.md
+++ b/docs/local-build-script.md
@@ -47,7 +47,6 @@ providers:
 | `-v` | OpenTelemetry Collector Builder version | `0.121.0` | No |
 | `-g` | Go version to use | `1.24.0` | No |
 | `-s` | Supervisor version | `0.122.0` | No |
-| `-i` | Build ID for artifact storage | Auto-generated | No |
 | `-h` | Show help message | N/A | No |
 
 The `-n` (parallelism) option is passed to the builder as `--parallelism` and controls how many build targets Goreleaser runs in parallel. See [Docker documentation](./docker.md) for the full list of builder options.
@@ -85,14 +84,6 @@ Build for `linux/amd64` or `darwin/arm64`:
   -v 0.121.0 \
   -g 1.24.0 \
   -s 0.122.0
-```
-
-### Custom Build ID
-
-```bash
-./scripts/run_local_build.sh \
-  -m manifest.yaml \
-  -i custom-build-123
 ```
 
 ## Using Make Commands

--- a/docs/local-multiarch-build-script.md
+++ b/docs/local-multiarch-build-script.md
@@ -6,7 +6,7 @@ This guide explains how to build custom OpenTelemetry Collector distributions fo
 
 Use `run_local_build.sh -p <platforms>` when you need collector binaries for several platforms (e.g. linux/amd64, linux/arm64, darwin/arm64) from one command. The script builds one Docker image for your host architecture (to avoid emulation issues) and runs the builder so it produces artifacts for all requested platforms.
 
-For a single platform, run `run_local_build.sh` without `-p` (default: linux/arm64). See [Using the Local Build Script](./local-build-script.md).
+For a single platform, run `run_local_build.sh` without `-p` (defaults to the host platform). See [Using the Local Build Script](./local-build-script.md).
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ providers:
 ./scripts/run_local_build.sh -m manifest.yaml -p linux/amd64,darwin/amd64,linux/arm64,darwin/arm64
 ```
 
-This builds the collector for linux and darwin (amd64 and arm64) and writes artifacts to `./artifacts`. Omit `-p` for a single-arch build (default: linux/arm64).
+This builds the collector for linux and darwin (amd64 and arm64) and writes artifacts to `./artifacts`. Omit `-p` for a single-arch build (defaults to the host platform).
 
 ## How It Works
 
@@ -56,7 +56,7 @@ This builds the collector for linux and darwin (amd64 and arm64) and writes arti
 |--------|-------------|---------|----------|
 | `-m` | Path to manifest file | None | Yes |
 | `-o` | Output directory for artifacts | `./artifacts` | No |
-| `-p` | Comma-delimited GOOS/GOARCH for collector binaries (omit for single-arch: linux/arm64) | None (single-arch) | No |
+| `-p` | Comma-delimited GOOS/GOARCH for collector binaries (omit for single-arch; defaults to host platform) | None (defaults to host platform) | No |
 | `-n` | Number of parallel Goreleaser build tasks (use 1 to reduce memory) | Builder default (4) | No |
 | `-v` | OpenTelemetry Collector Builder version | From manifest | No |
 | `-g` | Go version to use | From manifest/versions.yaml | No |


### PR DESCRIPTION
## Summary

- **Go dependency**: Remove false claim that Go is required for full builds — the CLI auto-downloads OCB and Go when needed (fixed in 5 locations across README and docs)
- **GitHub Action inputs**: Update inputs table in `README.md` and `docs/github-actions.md` to match `action.yml` — replace non-existent `output-dir`, `create_release`, `upload_artifacts`, `platforms` with actual inputs (`artifact_dir`, `os`, `arch`, `ocb_version`, `supervisor_version`, `go_version`); replace fictitious outputs table with accurate prose; rewrite all example workflows to use real inputs and a separate release step
- **Local build script**: Remove non-existent `-i` option from options table and example in `docs/local-build-script.md`
- **Default platform**: Fix "default: linux/arm64" wording in `docs/local-multiarch-build-script.md` → "defaults to the host platform"

## Test plan

- [ ] Review `README.md` inputs table matches `action.yml`
- [ ] Review `docs/github-actions.md` examples compile and use only real action inputs
- [ ] Confirm `docs/local-build-script.md` no longer references `-i`
- [ ] Confirm `docs/local-multiarch-build-script.md` no longer hardcodes `linux/arm64` as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)