### PR TITLE
fix: add -buildvcs=false to goreleaser build flags

### DIFF
--- a/builder/templates/.goreleaser.yaml
+++ b/builder/templates/.goreleaser.yaml
@@ -28,6 +28,7 @@ builds:
       - -w
     flags:
       - -trimpath
+      - -buildvcs=false  # required: OCB output dir has no .git, Go 1.18+ VCS stamping would fail
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
## Summary

- Add `-buildvcs=false` to the goreleaser `flags` list in `builder/templates/.goreleaser.yaml`

## Root cause

Go 1.18+ enables VCS stamping by default: `go build` tries to embed git revision info into the binary. When goreleaser runs with `dir: _build`, the working directory is OCB's generated output — there is no `.git` there. Go fails with:

```
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping.
```

This affects all builds that run inside Docker/CI (GitHub Action, local Docker) where the build executes in a directory outside a git repo.

## Fix

```yaml
flags:
  - -trimpath
  - -buildvcs=false  # required: OCB output dir has no .git, Go 1.18+ VCS stamping would fail
```

Version info is already controlled by `RELEASE_VERSION` and `ldflags`, so disabling VCS stamping loses nothing.

## Test plan

- [ ] Trigger a build (e.g. via `workflow_dispatch` or a test tag) and confirm `darwin/arm64` and other platforms complete without the VCS status error

🤖 Generated with [Claude Code](https://claude.com/claude-code)